### PR TITLE
Check whether fail2ban_filters exist

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,7 +54,8 @@
     mode: '0644'
   with_items: '{{ fail2ban_filters }}'
   notify: [ 'restart fail2ban' ]
-  when: ((item.name is defined and item.name) and
+  when: ((fail2ban_filters is defined) and
+         (item.name is defined and item.name) and
          (item.failregex is defined and item.failregex) and
          (item.state | d('present') not in ['absent']))
 
@@ -64,9 +65,9 @@
     state: 'absent'
   with_items: '{{ fail2ban_filters }}'
   notify: [ 'restart fail2ban' ]
-  when: ((item.name is defined and item.name) and
+  when: ((fail2ban_filters is defined) and
+         (item.name is defined and item.name) and
          (item.state | d('present') in ['absent']))
 
 - name: ensure fail2ban starts on a fresh reboot
   service: name=fail2ban state=started enabled=yes
-


### PR DESCRIPTION
Without this change, the playbook fails when `fail2ban_filters` is not set